### PR TITLE
setup.py: Install modules and scripts properly

### DIFF
--- a/mkvuser.py
+++ b/mkvuser.py
@@ -28,11 +28,12 @@ class MatroskaUser(mkvparse.MatroskaHandler):
         print("Frame for %d ts=%.06f l=%d %s len=%d data=%s..." %
                 (track_id, timestamp, more_laced_frames, addstr, len(data), binascii.hexlify(data[0:10])))
 
-if sys.version >= '3':
-    sys.stdin = sys.stdin.detach()
+if __name__ == '__main__':
+    if sys.version >= '3':
+        sys.stdin = sys.stdin.detach()
 
-# Reads mkv input from stdin, parse it and print details to stdout
-mkvparse.mkvparse(sys.stdin, MatroskaUser())
+    # Reads mkv input from stdin, parse it and print details to stdout
+    mkvparse.mkvparse(sys.stdin, MatroskaUser())
 
 
 # Output example:

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     license = "BSD",
     keywords = "mkv matroska",
     url = "https://github.com/vi/mkvparse",
-    packages=['mkvparse'],
-	package_dir={'mkvparse': ''},
+    py_modules=['mkvparse', 'mkvuser'],
+    scripts=['mkv2xml', 'xml2mkv'],
     long_description=read('README.md'),
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This will install `mkvparse` and `mkvuser` modules appropriately to be importable. And `mkv2xml` and `xml2mkv` scripts (or rather their wrappers) will be installed in `<prefix>/bin`